### PR TITLE
feat: 슬라임 잡고 레벨업

### DIFF
--- a/[W2]정렬_이진탐색/pine/슬라임 잡고 레벨업.py
+++ b/[W2]정렬_이진탐색/pine/슬라임 잡고 레벨업.py
@@ -1,0 +1,27 @@
+n = int(input())
+
+def getNeedExp(y):
+    return y*y-y
+    
+for _ in range(n):
+    monster = int(input())
+    exp = (monster*(1+monster))/2 # 획득 경험치수. 시작경험치:1, 마지막경험치:monster -> 등차수열 식
+    # needExp = 2
+    # y레벨일때, 레벨업에 필요한 경험치 -> 등차수열 식
+    # ((y-1) *(2+(2y-2)))/2 => y*y -y
+    # (y-1) = 레벌업 횟수
+    # 2 = 최초 레벨업에 필요한 경험치
+    # (2*y - 2) = 마지막 레벨업에 필요한 경험치
+    start= 1
+    end=monster
+    lv= int((start+end)//2)
+    if(monster == 1):
+        print(1)
+    else:
+        while not (getNeedExp(lv) <= exp <= getNeedExp(lv + 1)):
+            if exp >getNeedExp(lv): #경험치남음
+                start=lv
+            else: #경험치부족
+                end=lv
+            lv= int((start+end)//2)
+        print(lv)


### PR DESCRIPTION
## 문제 풀이
1. 획득 가능한 경험치양 계산
2. 임의로 레벨 설정, 해당 레벨 달성을 위해 필요한 경험치 계산
3. 예상 레벨 범위, start와 end를 이용
4. 레벨 달성하고도 경험치가 남을 경우 
  4.1 start 값을 현재 lv로 설정
  4.2 예상 레벨을 start와 end의 중간값으로 설정
5. 레벨 달성을 위한 경험치가 모자랄 경우
  5.1 end 값을 현재 lv로 설정
  5.2 예상 레벨을 start와 end의 중간값으로 설정
6. 반복 기준: needExp(lv)=<exp=<needExp(lv+1)일 경우 반복 종료

### 결과
16%에서 계속해서 실패.