### PR TITLE
[W5-1] 먹을 것인가 먹힐 것인가

### DIFF
--- a/05_먹을것인가먹힐것인가/pine/먹을것인가먹힐것인가.py
+++ b/05_먹을것인가먹힐것인가/pine/먹을것인가먹힐것인가.py
@@ -1,0 +1,42 @@
+case = int(input())
+    
+while case > 0:
+    count = 0 # 정답값. A가 먹을 수 있는 B 경우의 수
+    a_number, b_number = list(map(int, input().split())) 
+    a = sorted(list(map(int, input().split())),reverse=True)
+    b = sorted(list(map(int, input().split())))
+
+    min_b = b[0]
+    max_b = b[-1]
+
+    start = 0
+    end = b_number - 1 # 인덱스 값이기 때문에 -1
+
+    for target in a:
+        if target <= min_b: break # B의 최소값보다 타겟이 작을 경우 종료
+        if target > max_b: # B의 최대값보다 타겟이 클 경우 B의 수량만큼 카운트 추가
+            count += b_number
+            continue
+        
+        # 이진 탐색 시작
+        
+        while start <= end:
+            mid = (start + end)//2
+            if target<=b[mid]:
+                mid = mid-1
+                end = mid
+                if target > b[mid]: # b[mid] < target ≤ b[mid+1] 검증
+                    break
+                else: continue
+            else: # (= b[mid] < target)인 경우
+                start = mid+1
+                if target < b[mid+1]: # b[mid] < target ≤ b[mid+1] 검증
+                    break 
+                else: continue
+                
+        # 이진탐색 종료. mid값을 찾은 후, star/end 값 초기화
+        start = 0
+        end = mid # A는 내림차순 정렬이기 때문에, 다음 타겟의 end는 현태 타겟의 mid보다 반드시 작다.
+        count += mid+1 # mid는 인덱스값이기 때문에 수량으로 변환(+1)
+    print(count)
+    case -= 1


### PR DESCRIPTION
# 관련 이슈
> #17 

# 작업 내용

[풀이방식]
1. A와 B 배열을 생성한뒤, A는 내림차순, B는 오름차순으로 정렬한다.
    (내림차순 이유는 코드에서 추가 설명)
2. 이진 탐색이 필요없는 경우, 예외 처리(타겟: A 그룹에서 이진 탐색을 돌릴 대)
    2-1) B의 최소값보다 타겟의 값이 적을 경우 → 타겟이 먹을 수 있는 대상이 없음
    2-2) B의 최대값보다 타겟이 큰 경우 → B의 모든 값을 먹을 수 있음
3. 이진 탐색을 진행하며, A가 B를 먹을 수 있는 경우의 수 판별

[로직 추가 설명]
- 이진 탐색을 통한 범위 축소 작업과, 현재 설정된 mid값이 정답값인지 판단하는 작업을 진행한다.
- 이때, 정답이란 이분 탐색을 진행중인 A의 현재 타겟이 잡아 먹을 수 있는 B의 최대값(정답값)을 찾은 경우를 말한다.
- B는 오름차순 정렬이 되어있기 때문에, 정답값의 인덱스보다 하위 인덱스의 값들은 전부 먹을 수 있다.
- **정답 조건**: b[mid] < target ≤ b[mid+1]  → 조건이 성립시 mid(B의 인덱스)값이 target이 먹을 수 있는 B의 최대값이다.


# 문제 요약
- [[백준] 7795 먹을것인가 먹힐것인가](https://www.acmicpc.net/problem/7795)

1. A, B그룹이 존재한다. 그룹에는 숫자 형태의 생명체가 존재한다.
2. A그룹은 B그룹에서 자신보다 크기가 작은 숫자만 먹을 수 있다.
3. 테스트 케이스가 여러개 주어질때, 각 테스트 케이스마다 A가 B보다 큰 쌍의 개수를 출력해라
     (=  A의 숫자들이 B를 먹을 수 있는 경우의 수를 구하라)
5. 이때, 중복된 숫자들이 있을 수 있으며, 숫자는 같더라도 별개의 생명체이다

# 고민 방향
현재 이진 탐색 코드에서 if를 이용해 정답 조건에 해당하는지 한번 더 검증하고 있다.
이런 방법을 쓰지 않고 바로 정답을 구할 수 있는 방법으로 리팩토링이 가능할지 고민중이다.
정답 조건을 추가 점검하는 if문이 없어도 정답일것이라고 생각했으나, 해당 부분을 제거하면 문제를 틀리는 상황이 발생했다.
이 부분이 가독성을 떨어트리는 것 같다.